### PR TITLE
Add math related abbreviations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ Colored circles before the abbr mean the degree of recommendation:
 - alternative • 🟢 alt
 - annotation • 🟢 anno
 - application • 🟢 app
+- arccosecant • 🟢 acosec
 - arccosine • 🟢 acos
+- arccotangent • 🟢 acot • 🟢 actg
+- arcsecant • 🟢 asec
 - arcsine • 🟢 asin
 - arctangent • 🟢 atan
 - argument • 🟢 arg
@@ -161,7 +164,6 @@ Colored circles before the abbr mean the degree of recommendation:
 ### G
 - generation • 🟢 gen
 - geometry • 🟢 geom
-- geometric • 🟢 geom
 - greater or equal • 🟡 ge { binary operations }
 - greater than • 🟡 gt { binary operations }
 
@@ -188,7 +190,6 @@ Colored circles before the abbr mean the degree of recommendation:
 - integer • 🟢 int
 - interface • 🟢 iface • 🔴 intf
 - inverse • 🟢 inv
-- inverted • 🟢 inv
 - iterator • 🟡 iter { loops }
 
 ### J
@@ -214,7 +215,6 @@ Colored circles before the abbr mean the degree of recommendation:
 
 ### M
 - manager • 🟢 mng
-- mathematic • 🟢 math
 - matrix • 🟡 mtx { mathematics } • 🟡 mat { mathematics }
 - maximum • 🟢 max
 - memory • 🟢 mem

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Colored circles before the abbr mean the degree of recommendation:
 - alternative • 🟢 alt
 - annotation • 🟢 anno
 - application • 🟢 app
+- arccosine • 🟢 acos
+- arcsine • 🟢 asin
+- arctangent • 🟢 atan
 - argument • 🟢 arg
 - array • 🟢 arr
 - asynchronous • 🟢 async
@@ -91,8 +94,9 @@ Colored circles before the abbr mean the degree of recommendation:
 - conversation • 🟢 conv
 - coordinate • 🟢 coord
 - copy • 🔴 cpy
+- cosecant • 🟢 cosec
 - cosine • 🟢 cos
-- cotangent • 🟢 cot
+- cotangent • 🟢 cot • 🟢 ctg
 - count • 🟢 cnt
 - current • 🔴 cur • 🟢 curr
 
@@ -104,6 +108,7 @@ Colored circles before the abbr mean the degree of recommendation:
 - decrease • 🟡 dec { loops }
 - default • 🔴 def
 - definition • 🟢 def
+- degrees • 🟢 deg
 - deletion • 🟢 del
 - delta time • 🟡 dt { calculations }
 - dependency • 🟢 dep
@@ -132,6 +137,7 @@ Colored circles before the abbr mean the degree of recommendation:
 - error • 🟢 err
 - event • 🟢 e • 🟢 evt
 - execution • 🟢 exe
+- exponential • 🟢 exp
 - expression • 🟢 expr
 - extension • 🟢 ext
 
@@ -154,6 +160,8 @@ Colored circles before the abbr mean the degree of recommendation:
 
 ### G
 - generation • 🟢 gen
+- geometry • 🟢 geom
+- geometric • 🟢 geom
 - greater or equal • 🟡 ge { binary operations }
 - greater than • 🟡 gt { binary operations }
 
@@ -179,6 +187,8 @@ Colored circles before the abbr mean the degree of recommendation:
 - instance • 🟢 inst
 - integer • 🟢 int
 - interface • 🟢 iface • 🔴 intf
+- inverse • 🟢 inv
+- inverted • 🟢 inv
 - iterator • 🟡 iter { loops }
 
 ### J
@@ -204,6 +214,8 @@ Colored circles before the abbr mean the degree of recommendation:
 
 ### M
 - manager • 🟢 mng
+- mathematic • 🟢 math
+- matrix • 🟡 mtx { mathematics } • 🟡 mat { mathematics }
 - maximum • 🟢 max
 - memory • 🟢 mem
 - message • 🟢 msg
@@ -262,6 +274,7 @@ Colored circles before the abbr mean the degree of recommendation:
 - query • 🟢 q • 🔴 qry
 
 ### R
+- radians • 🟢 rad
 - radius • 🟡 r { circles }
 - random • 🟢 rand • 🔴 rnd
 - range • 🟢 rng
@@ -282,6 +295,7 @@ Colored circles before the abbr mean the degree of recommendation:
 
 ### S
 - script • 🔴 sc
+- secant • 🟢 sec
 - selection • 🟢 sel
 - semaphore • 🟡 sem { conditional operators }
 - separator • 🟢 sep


### PR DESCRIPTION
**Mathematic terms:**
- mathematic • math : Useful for class names or lib names | Ex: rpc_math, math_lib, math_basics
- matrix • mtx / mat : Used for math purposes related to matrix operations | Ex: mtx_scale(), mtx_rot(), new_mat(), cpy_mat

**Trigonometric functions:**
- arccosine • acos
- arcsine • asin
- arctangent • atan
- cosecant • cosec
- cotangent • cot • ctg
- secant • sec

**Mathematic measures:**
- degrees • deg
- radians • rad

**Matrix operations:**
- inverse • inv
- inverted • inv